### PR TITLE
Use flexible range so that customers would pickup latest version of MSAL

### DIFF
--- a/FlaskAPI/requirements.txt
+++ b/FlaskAPI/requirements.txt
@@ -22,7 +22,7 @@ jinja2>=2.11.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2
 
 markupsafe==1.1.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 
-msal==1.7.0
+msal>=1.7.0,<2
 
 pyasn1==0.4.8
 


### PR DESCRIPTION
Our telemetry indicates that some newly created apps were using older version of MSAL. We hope a flexible range in samples would help customers to automatically pick up later version of MSAL.

MSAL uses semantic versioning. Apps using 1.x versions can safely upgrade to use a later version of MSAL 1.x.